### PR TITLE
Hotfix Sentry heroku

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "react-app-rewired start",
     "build": "SENTRY_COMMIT_HASH=`sentry-cli releases propose-version` react-app-rewired build",
+    "build:heroku": "SENTRY_COMMIT_HASH=$HEROKU_SLUG_COMMIT react-app-rewired build",
     "eject": "react-app-rewired eject",
     "eslint": "eslint src --max-warnings=0",
     "flow": "flow",


### PR DESCRIPTION
The build environment on heroku does not have `.git` directory in workspace, resulting in `sentry-cli releases propose-version` (which reads latest git commit hash) raising an error.

However, heroku commit hash can be available by  `$HEROKU_SLUG_COMMIT` variable.

I don't see any better resolution for this at the moment, but let me know if you think it should be solved in some other way.