### PR TITLE
Hotfix Sentry envs assert

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -2,6 +2,8 @@
 
 import assert from 'assert'
 
+const isProduction = process.env.NODE_ENV === 'production'
+
 const graphQLServerUrl = process.env.REACT_APP_GRAPHQL_SERVER_URL
 assert(graphQLServerUrl)
 
@@ -9,10 +11,10 @@ const googleAnalyticsId = process.env.REACT_APP_GOOGLE_ANALYTICS_ID
 assert(googleAnalyticsId)
 
 const sentryDSN = process.env.REACT_APP_SENTRY_DSN
-assert(sentryDSN)
+isProduction && assert(sentryDSN)
 
 const sentryRelease = process.env.REACT_APP_SENTRY_RELEASE_VERSION
-assert(sentryRelease)
+isProduction && assert(sentryRelease)
 
 export default {
   googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAPS_API_KEY,
@@ -23,5 +25,5 @@ export default {
     dsn: sentryDSN || '', // flow does not know about above assert
     releaseVersion: sentryRelease || '', // flow does not know about above assert
   },
-  isProduction: process.env.NODE_ENV === 'production',
+  isProduction,
 }


### PR DESCRIPTION
So that assert for sentry env variables are only run on production environment