### PR TITLE
Simple page view tracking

### DIFF
--- a/frontend/src/helpers/googleAnalytics.js
+++ b/frontend/src/helpers/googleAnalytics.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {useEffect} from 'react'
 import _ from 'lodash'
 import config from '@/config'
 
@@ -24,6 +25,14 @@ const formatter = (v: string) =>
 const trackEvent = (resourceName: string, actionName: string, label?: string) => {
   const f = formatter
   gtag('event', `${f(resourceName)} ${f(actionName)}`, label ? {event_label: label} : {})
+}
+
+const useTrackPageVisitEvent = (screenName: string) => {
+  const f = formatter
+  useEffect(() => {
+    gtag('event', 'screen_view', {screen_name: f(screenName)})
+    // We want to call this only once
+  }, []) // eslint-disable-line
 }
 
 const trackSearchEvent = (resourceName: string) => {
@@ -70,6 +79,7 @@ const initGoogleAnalytics = () => {
 }
 
 export default {
+  useTrackPageVisitEvent,
   trackSearchEvent,
   trackChartEvent,
   trackCurrencyChanged,

--- a/frontend/src/screens/Blockchain/Address/index.js
+++ b/frontend/src/screens/Blockchain/Address/index.js
@@ -10,6 +10,7 @@ import idx from 'idx'
 import {GET_ADDRESS_BY_ADDRESS58} from '@/api/queries'
 import {useI18n} from '@/i18n/helpers'
 import {useScrollFromBottom} from '@/components/hooks/useScrollFromBottom'
+import analytics from '@/helpers/googleAnalytics'
 
 import WithModalState from '@/components/headless/modalState'
 import PagedTransactions from './PagedTransactions'
@@ -116,6 +117,8 @@ const AddressScreen = () => {
   const {translate: tr} = useI18n()
   const classes = useStyles()
   const scrollToRef = useRef(null)
+
+  analytics.useTrackPageVisitEvent('address')
 
   useScrollFromBottom(scrollToRef, addressSummary)
 

--- a/frontend/src/screens/Blockchain/Block/index.js
+++ b/frontend/src/screens/Blockchain/Block/index.js
@@ -19,6 +19,7 @@ import {
 } from '@/components/visual'
 
 import {useScrollFromBottom} from '@/components/hooks/useScrollFromBottom'
+import analytics from '@/helpers/googleAnalytics'
 
 import TransactionCard from '@/components/common/TransactionCard'
 
@@ -208,6 +209,8 @@ const BlockScreen = () => {
   const {loading, blockData, error} = useBlockData({blockHash})
   const {translate} = useI18n()
   const scrollToRef = useRef()
+
+  analytics.useTrackPageVisitEvent('block')
 
   useScrollFromBottom(scrollToRef, blockData)
 

--- a/frontend/src/screens/Blockchain/Epoch/index.js
+++ b/frontend/src/screens/Blockchain/Epoch/index.js
@@ -27,6 +27,7 @@ import {routeTo} from '@/helpers/routes'
 import config from '@/config'
 import {useQueryNotBugged} from '@/components/hooks/useQueryNotBugged'
 import {useScrollFromBottom} from '@/components/hooks/useScrollFromBottom'
+import analytics from '@/helpers/googleAnalytics'
 
 import NavigationButtons from '../NavigationButtons'
 
@@ -291,6 +292,8 @@ const EpochScreen = () => {
 
   const {translate: tr} = useI18n()
   const blocksInEpoch = idx(epochData, (_) => _.summary.blocksCreated)
+
+  analytics.useTrackPageVisitEvent('epoch')
 
   useScrollFromBottom(scrollToRef, epochData)
 

--- a/frontend/src/screens/Blockchain/NotFound.js
+++ b/frontend/src/screens/Blockchain/NotFound.js
@@ -4,6 +4,7 @@ import React from 'react'
 import {makeStyles} from '@material-ui/styles'
 
 import PageNotFound from '../PageNotFound'
+import analytics from '@/helpers/googleAnalytics'
 
 const useStyles = makeStyles((theme) => ({
   wrapper: {
@@ -16,6 +17,9 @@ const useStyles = makeStyles((theme) => ({
 // For now using simpler, not perfect styling solution.
 export default () => {
   const classes = useStyles()
+
+  analytics.useTrackPageVisitEvent('404-blockchain')
+
   return (
     <div className={classes.wrapper}>
       <PageNotFound />

--- a/frontend/src/screens/Blockchain/PagedBlocks/index.js
+++ b/frontend/src/screens/Blockchain/PagedBlocks/index.js
@@ -17,6 +17,7 @@ import {useQueryNotBugged} from '@/components/hooks/useQueryNotBugged'
 import {useManageQueryValue} from '@/components/hooks/useManageQueryValue'
 import {toIntOrNull} from '@/helpers/utils'
 import BlocksTable, {ALL_COLUMNS} from './BlocksTable'
+import analytics from '@/helpers/googleAnalytics'
 
 const AUTOUPDATE_REFRESH_INTERVAL = 10 * 1000
 
@@ -97,6 +98,8 @@ const PagedBlocks = () => {
   )
 
   const pagedBlocks = pagedDataResult.pagedData
+
+  analytics.useTrackPageVisitEvent('blocks')
 
   return (
     <SimpleLayout title={translate(messages.header)}>

--- a/frontend/src/screens/Blockchain/StakePool/index.js
+++ b/frontend/src/screens/Blockchain/StakePool/index.js
@@ -16,6 +16,7 @@ import {
 
 import {useScrollFromBottom} from '@/components/hooks/useScrollFromBottom'
 import {useI18n} from '@/i18n/helpers'
+import analytics from '@/helpers/googleAnalytics'
 
 const summaryLabels = defineMessages({
   name: 'Name',
@@ -75,6 +76,8 @@ const StakePool = () => {
   const {loading, stakePoolData, error} = useStakePoolData(poolHash)
   const {translate} = useI18n()
   const scrollToRef = useRef()
+
+  analytics.useTrackPageVisitEvent('stakepool')
 
   useScrollFromBottom(scrollToRef, stakePoolData)
 

--- a/frontend/src/screens/Blockchain/Transaction/index.js
+++ b/frontend/src/screens/Blockchain/Transaction/index.js
@@ -26,6 +26,7 @@ import AdaIcon from '@/assets/icons/transaction-id.svg'
 import {ASSURANCE_LEVELS_VALUES} from '@/constants'
 import {useI18n} from '@/i18n/helpers'
 import {routeTo} from '@/helpers/routes'
+import analytics from '@/helpers/googleAnalytics'
 
 const messages = defineMessages({
   header: 'Transaction',
@@ -176,6 +177,8 @@ const TransactionScreen = () => {
   const {loading, transactionData, error} = useTransactionData(txHash)
   const {translate} = useI18n()
   const scrollToRef = useRef(null)
+
+  analytics.useTrackPageVisitEvent('transaction')
 
   useScrollFromBottom(scrollToRef, transactionData)
 

--- a/frontend/src/screens/Home/index.js
+++ b/frontend/src/screens/Home/index.js
@@ -2,6 +2,7 @@
 import React from 'react'
 
 import config from '@/config'
+import analytics from '@/helpers/googleAnalytics'
 import BlockchainHeader from '@/screens/Blockchain/BlockchainHeader'
 import GeneralInfo from './GeneralInfo'
 import StakePoolsInfo from './StakePoolsInfo'
@@ -9,12 +10,15 @@ import Charts from './Charts'
 
 import SyncIssuesBar from '@/components/common/SyncIssuesBar'
 
-export default () => (
-  <React.Fragment>
-    <BlockchainHeader />
-    <SyncIssuesBar />
-    <Charts />
-    {config.showStakingData && <StakePoolsInfo />}
-    <GeneralInfo />
-  </React.Fragment>
-)
+export default () => {
+  analytics.useTrackPageVisitEvent('home')
+  return (
+    <React.Fragment>
+      <BlockchainHeader />
+      <SyncIssuesBar />
+      <Charts />
+      {config.showStakingData && <StakePoolsInfo />}
+      <GeneralInfo />
+    </React.Fragment>
+  )
+}

--- a/frontend/src/screens/PageNotFound.js
+++ b/frontend/src/screens/PageNotFound.js
@@ -4,6 +4,7 @@ import {makeStyles} from '@material-ui/styles'
 import {defineMessages} from 'react-intl'
 
 import {useI18n} from '@/i18n/helpers'
+import analytics from '@/helpers/googleAnalytics'
 import errorImage from '@/assets/error-screen.svg'
 
 const messages = defineMessages({
@@ -23,6 +24,9 @@ const useStyles = makeStyles((theme) => ({
 const PageNotFound = () => {
   const classes = useStyles()
   const {translate: tr} = useI18n()
+
+  analytics.useTrackPageVisitEvent('404')
+
   return (
     <Grid
       className={classes.wrapper}


### PR DESCRIPTION
* @ppershing as we cannot log whole pathnames this might be easy workaround at least for MVP, as I am not sure how to make tracking working with router/link when we want to track just partial info (like /blockchain/transaction/ID -> 'Transaction'). I don't know if there is some better, simple enough way.