### PR TITLE
Hotfix: Urls on Address screen

### DIFF
--- a/frontend/src/components/hooks/useUrlManager.js
+++ b/frontend/src/components/hooks/useUrlManager.js
@@ -7,24 +7,26 @@ import useReactRouter from 'use-react-router'
 import * as urlUtils from '@/helpers/url'
 
 export const useUrlManager = () => {
-  const {history, location} = useReactRouter()
+  const {history} = useReactRouter()
 
   const setQueryParam = React.useCallback(
     (key: string, value: any) => {
       history.replace({
-        search: urlUtils.replaceQueryParam(location.search, key, value),
+        // TODO: investigate
+        // in components, where multiple useUrlManager hooks are used,
+        // location.search from useReactRouter is sometimes empty here, for an unknown reason,
+        // thus not reflecting the latest URL state
+        // and resulting in overwriting the URL changed by other useUrlManager hooks
+        search: urlUtils.replaceQueryParam(window.location.search, key, value),
       })
     },
-    [history, location]
+    [history]
   )
 
-  const getQueryParam = React.useCallback(
-    (paramKey: string, query?: string): any => {
-      const parsed = urlUtils.parse(query || location.search)
-      return parsed[paramKey]
-    },
-    [location]
-  )
+  const getQueryParam = React.useCallback((paramKey: string, query?: string): any => {
+    const parsed = urlUtils.parse(query || window.location.search)
+    return parsed[paramKey]
+  }, [])
 
   const setQuery = React.useCallback(
     (query: string) => {


### PR DESCRIPTION
@rizip1 , I couldn't really find the exact reason why is this happening...
...but sometimes one `useUrlManager` seen other `location.search` than the other, I don't know why.

I just replaced it with global `window.location.search`

I also looked into source code of `use-react-router`, but I wasn't able to find the issue. I didn't know if it's because of the hooks or what :/.

I was also thinking, if we could somehow replace `useReactRouter` with `withRouter` and compare the results, but I didn't really know how, because when you're that nested inside the hooks you can't really use a HOC there. Not only I wanted to look into whether that would fix the problem itself, but I also noticed, that `use-react-router` uses `forceUpdate` under the hood, which might be cause of many re-renders on Address screen which might be the source of performance affection....