### PR TITLE
Adds sourcemap for graphql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.swo
 node_modules
 .history
+graphql-server/.idea
+.idea

--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -7,7 +7,7 @@
     "start": "if test $NODE_ENV = production; then yarn start:production; else NODE_ENV=development babel-watch src/index.js -w src/graphql; fi",
     "start:production": "NODE_ENV=production SENTRY_RELEASE_VERSION=`sentry-cli releases propose-version` node build/index.js",
     "start:heroku": "`sentry-cli releases new $HEROKU_SLUG_COMMIT; SENTRY_RELEASE_VERSION=$HEROKU_SLUG_COMMIT node build/index.js`",
-    "build": "rm -rf build && babel src --out-dir build",
+    "build": "rm -rf build && babel src --out-dir build --source-maps",
     "build:heroku": "yarn build",
     "serve": "node build/index.js",
     "eslint": "eslint src --max-warnings=0",


### PR DESCRIPTION
It’s pretty difficult to debug the errors from Sentry. If we had sourcemaps it would help a little bit. I added sourcemaps for GraphQL.

This is only less than half of the task, we also need to upload the sourcemaps to Sentry while we are creating a new release. More instructions here: https://docs.sentry.io/platforms/javascript/sourcemaps/