### PR TITLE
Forbid google translation

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <!-- We remove auto translate as it causes React apps to fail -->
     <meta name="google" content="notranslate">
     <meta name="theme-color" content="#000000" />
     <!--
@@ -25,6 +26,7 @@
     -->
     <title>Seiza</title>
   </head>
+  <!-- We remove auto translate as it causes React apps to fail -->
   <body class="notranslate">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>


### PR DESCRIPTION
Business:
Google translate caused issues when used in conjuction with our library.
We forbid the Google translate to prevent such an issue from happening.

For developers:
https://stackoverflow.com/questions/9628507/how-can-i-tell-google-translate-to-not-translate-a-section-of-a-website/9629628

https://stackoverflow.com/questions/12238396/how-to-disable-google-translate-from-html-in-chrome