### PR TITLE
Show Transactions count of the tabs on Address screen

### DIFF
--- a/frontend/src/screens/Blockchain/Address/index.js
+++ b/frontend/src/screens/Blockchain/Address/index.js
@@ -203,7 +203,6 @@ const AddressScreen = () => {
   } = transactionsData
 
   const transactions = idx(addressTransactions, (_) => _.transactions) || []
-  const transactionCount = idx(addressSummary, (_) => _.transactionsCount)
 
   const totalCount = idx(addressTransactions, (_) => _.totalCount) || 0
 
@@ -262,7 +261,7 @@ const AddressScreen = () => {
             <div className={classes.headingWrapper}>
               <EntityHeading>
                 {tr(messages.transactionsHeading, {
-                  count: transactionCount,
+                  count: totalCount,
                 })}
               </EntityHeading>
             </div>


### PR DESCRIPTION
Previously Transactions count on Address screen was showing count per currently open tab.
Now it shows count of ALL Transactions regardless of whether it's a sent or received transaction.