### PR TITLE
Fix search cache

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -10,3 +10,8 @@ export const ASSURANCE_LEVELS = {
 }
 
 export const ASSURANCE_LEVELS_VALUES = ASSURANCE_LEVELS.NORMAL
+
+export const APOLLO_CACHE_OPTIONS = {
+  CACHE_AND_NETWORK: 'cache-and-network',
+  NO_CACHE: 'no-cache',
+}

--- a/frontend/src/screens/Blockchain/Address/index.js
+++ b/frontend/src/screens/Blockchain/Address/index.js
@@ -36,6 +36,7 @@ import addressIcon from '@/assets/icons/qrcode.svg'
 import {extractError} from '@/helpers/errors'
 
 import {FILTER_TYPES} from './constants'
+import {APOLLO_CACHE_OPTIONS} from '@/constants'
 
 const summaryMessages = defineMessages({
   NA: 'N/A',
@@ -108,6 +109,7 @@ const useStyles = makeStyles((theme) => ({
 const useAddressSummary = (address58) => {
   const {loading, data, error} = useQueryNotBugged(GET_ADDRESS_BY_ADDRESS58, {
     variables: {address58},
+    fetchPolicy: APOLLO_CACHE_OPTIONS.CACHE_AND_NETWORK,
   })
 
   // TODO: how to extract error properly???
@@ -117,6 +119,7 @@ const useAddressSummary = (address58) => {
 const useTransactions = (address58, filterType, cursor) => {
   const {loading, data, error} = useQueryNotBugged(GET_TXS_BY_ADDRESS, {
     variables: {address58, filterType, cursor},
+    fetchPolicy: APOLLO_CACHE_OPTIONS.CACHE_AND_NETWORK,
   })
 
   // TODO: how to extract error properly???

--- a/frontend/src/screens/Blockchain/Block/index.js
+++ b/frontend/src/screens/Blockchain/Block/index.js
@@ -30,6 +30,8 @@ import {routeTo} from '@/helpers/routes'
 import {extractError} from '@/helpers/errors'
 import SlotNavigation from './SlotNavigation'
 
+import {APOLLO_CACHE_OPTIONS} from '@/constants'
+
 const blockSummaryLabels = defineMessages({
   epoch: 'Epoch',
   slot: 'Slot',
@@ -165,6 +167,7 @@ const useBlockData = ({blockHash}) => {
     `,
     {
       variables: {blockHash},
+      fetchPolicy: APOLLO_CACHE_OPTIONS.CACHE_AND_NETWORK,
     }
   )
   const {loading, error, data} = result

--- a/frontend/src/screens/Blockchain/BlockchainHeader/Search.js
+++ b/frontend/src/screens/Blockchain/BlockchainHeader/Search.js
@@ -15,6 +15,7 @@ import {useI18n} from '@/i18n/helpers'
 import {Searchbar, LoadingError, Alert} from '@/components/visual'
 import {routeTo} from '@/helpers/routes'
 import {useAnalytics} from '@/helpers/googleAnalytics'
+import {APOLLO_CACHE_OPTIONS} from '@/constants'
 
 const text = defineMessages({
   searchPlaceholder: 'Search addresses, transactions, epochs & slots on the Cardano network',
@@ -49,6 +50,7 @@ const useSearchData = (searchQuery, skip) => {
     `,
     {
       variables: {searchQuery},
+      fetchPolicy: APOLLO_CACHE_OPTIONS.NO_CACHE,
       skip,
     }
   )

--- a/frontend/src/screens/Blockchain/Epoch/index.js
+++ b/frontend/src/screens/Blockchain/Epoch/index.js
@@ -32,6 +32,7 @@ import {useScrollFromBottom} from '@/components/hooks/useScrollFromBottom'
 import {useAnalytics} from '@/helpers/googleAnalytics'
 
 import NavigationButtons from '../NavigationButtons'
+import {APOLLO_CACHE_OPTIONS} from '@/constants'
 
 const messages = defineMessages({
   notAvailable: 'N/A',
@@ -219,10 +220,7 @@ const useEpochNavigation = (epochNumber: number) => {
 const useEpochData = (epochNumber) => {
   const {loading, error, data} = useQueryNotBugged(GET_EPOCH_BY_NUMBER, {
     variables: {epochNumber},
-    query: {
-      fetchPolicy: 'network-only',
-      errorPolicy: 'all',
-    },
+    fetchPolicy: APOLLO_CACHE_OPTIONS.CACHE_AND_NETWORK,
   })
   return {
     loading,

--- a/frontend/src/screens/Blockchain/Transaction/index.js
+++ b/frontend/src/screens/Blockchain/Transaction/index.js
@@ -23,7 +23,7 @@ import AddressesBreakdown from '@/components/common/AddressesBreakdown'
 import AssuranceChip from '@/components/common/AssuranceChip'
 import AdaIcon from '@/assets/icons/transaction-id.svg'
 
-import {ASSURANCE_LEVELS_VALUES} from '@/constants'
+import {ASSURANCE_LEVELS_VALUES, APOLLO_CACHE_OPTIONS} from '@/constants'
 import {useI18n} from '@/i18n/helpers'
 import {routeTo} from '@/helpers/routes'
 import {useAnalytics} from '@/helpers/googleAnalytics'
@@ -158,6 +158,7 @@ const useTransactionData = (txHash) => {
     `,
     {
       variables: {txHash},
+      fetchPolicy: APOLLO_CACHE_OPTIONS.CACHE_AND_NETWORK,
     }
   )
   return {loading, error: extractError(error, ['transaction']), transactionData: data.transaction}


### PR DESCRIPTION
* Don't cache resources when searching, so that when e.g. there is new Transaction for previously searched Address, it will be shown after Search for that Address is executed again.