### PR TITLE
Hotfix slot table on epoch screen

### DIFF
--- a/frontend/src/components/hooks/useBlocksTablePagedProps.js
+++ b/frontend/src/components/hooks/useBlocksTablePagedProps.js
@@ -2,33 +2,18 @@
 
 // Note!!!: pages are numbered from 1 so that urls is consistent with the rest of UI
 
-import {useState, useCallback, useEffect} from 'react'
+import {useCallback, useEffect} from 'react'
 import {getPageCount} from '@/components/visual/Pagination'
 
 // TODO: for now `PAGE_SIZE` is hardcoded both in client and server
 const PAGE_SIZE = 10
 
-export const useTotalItemsCount = (pagedDataResult: any, autoUpdate?: boolean) => {
-  // $FlowFixMe
-  const [totalItemsCount, setTotalItemsCount] = useState(0)
+export const rowsPerPage = PAGE_SIZE
+
+export const getTotalItemsCount = (pagedDataResult: {cursor: number, pagedData: Array<{}>}) => {
   const {cursor, pagedData} = pagedDataResult
-
-  useEffect(() => {
-    if (autoUpdate || totalItemsCount === 0) {
-      const dataCount = pagedData && pagedData.length
-
-      if (dataCount) {
-        const newTotalItemsCount = dataCount + cursor
-        newTotalItemsCount !== totalItemsCount && setTotalItemsCount(newTotalItemsCount)
-      }
-    }
-    // Note: we can not depend on `autoUpdate` because when it changes this receives old data first,
-    // without apollo `loading` state being changed to true in that moment.
-    // It does not matter that we do not depend on autoupdate, as when autoupdate changes also
-    // pagedData changes.
-  }, [pagedData]) // eslint-disable-line
-
-  return [totalItemsCount, setTotalItemsCount]
+  const dataCount = pagedData.length
+  return dataCount + cursor
 }
 
 // TODO: any better name for this?

--- a/frontend/src/components/hooks/useQueryNotBugged.js
+++ b/frontend/src/components/hooks/useQueryNotBugged.js
@@ -16,3 +16,18 @@ export const useQueryNotBugged = (...args: any) => {
 
   return {data: notNullData, error, loading, ...rest}
 }
+
+// Leaving previous version, so we can use do quick fix without testing
+// other parts of app, and unify those hooks later
+export const useQueryNotBuggedForBlocks = (...args: any) => {
+  const [notNullData, setNotNullData] = useState({})
+  const {data, error, loading, ...rest} = useQuery(...args)
+
+  useEffect(() => {
+    if (data && !loading) {
+      setNotNullData(data)
+    }
+  }, [data, loading])
+
+  return {data: loading ? notNullData : data || notNullData, error, loading, ...rest}
+}

--- a/frontend/src/screens/Blockchain/Epoch/Blocks.js
+++ b/frontend/src/screens/Blockchain/Epoch/Blocks.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, {useState, useEffect} from 'react'
 import idx from 'idx'
 import {defineMessages} from 'react-intl'
 import {Grid, Hidden} from '@material-ui/core'
@@ -9,9 +9,10 @@ import {GET_PAGED_BLOCKS_IN_EPOCH} from '@/api/queries'
 import {useI18n} from '@/i18n/helpers'
 import {
   useBlocksTablePagedProps,
-  useTotalItemsCount,
+  rowsPerPage,
+  getTotalItemsCount,
 } from '@/components/hooks/useBlocksTablePagedProps'
-import {useQueryNotBugged} from '@/components/hooks/useQueryNotBugged'
+import {useQueryNotBuggedForBlocks} from '@/components/hooks/useQueryNotBugged'
 import {EntityHeading} from '@/components/visual'
 import {useManageQueryValue} from '@/components/hooks/useManageQueryValue'
 import {toIntOrNull} from '@/helpers/utils'
@@ -45,7 +46,7 @@ const messages = defineMessages({
 })
 
 const useLoadData = (cursor, epochNumber) => {
-  const {error, loading, data} = useQueryNotBugged(GET_PAGED_BLOCKS_IN_EPOCH, {
+  const {error, loading, data} = useQueryNotBuggedForBlocks(GET_PAGED_BLOCKS_IN_EPOCH, {
     variables: {cursor, epochNumber},
     notifyOnNetworkStatusChange: true,
   })
@@ -53,8 +54,8 @@ const useLoadData = (cursor, epochNumber) => {
   const pagedData = idx(data.pagedBlocksInEpoch, (_) => _.blocks)
 
   return {
-    error,
     loading,
+    error,
     pagedDataResult: {
       ...data.pagedBlocksInEpoch,
       pagedData,
@@ -71,17 +72,44 @@ const Blocks = ({blocksCount, epochNumber}) => {
 
   const [page, setPage] = useManageQueryValue('page', null, toIntOrNull)
   const [cursor, setCursor] = useState(null)
-
   const {pagedDataResult, loading, error} = useLoadData(cursor, epochNumber)
-  const [totalItemsCount, setTotalItemsCount] = useTotalItemsCount(pagedDataResult)
+  const [totalItemsCount, setTotalItemsCount] = useState(0)
 
-  const {onChangePage, rowsPerPage} = useBlocksTablePagedProps(
+  const [prevEpoch, setPrevEpoch] = useState(epochNumber)
+
+  const {onChangePage} = useBlocksTablePagedProps(
     page,
     setPage,
     setCursor,
     totalItemsCount,
     setTotalItemsCount
   )
+
+  // Reset values after epoch was changed
+  // TODO: this is hot-fix, lets refactor this part soon as it is fragile
+  useEffect(() => {
+    if (epochNumber !== prevEpoch) {
+      setPrevEpoch(epochNumber)
+      setCursor(null)
+      setPage(null)
+      setTotalItemsCount(0)
+    }
+
+    // TODO: consider nicer solution, hot fix for now
+    if (!loading && pagedDataResult.pagedData) {
+      if (cursor == null) {
+        setCursor(
+          page
+            ? Math.min(getTotalItemsCount(pagedDataResult), page * rowsPerPage)
+            : getTotalItemsCount(pagedDataResult)
+        )
+      }
+      if (totalItemsCount === 0) {
+        setTotalItemsCount(getTotalItemsCount(pagedDataResult))
+      }
+    }
+  })
+
   const {blocks} = pagedDataResult
 
   const pagination = (


### PR DESCRIPTION
Fix Blocks table on epoch screen. After changing the selected page in table and reloading URL, the table was populated with incorrect data. Also changing epoch did not reset pagination in the table. 