### PR TITLE
Show help text of Search on mobile only when input is focused

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,6 +35,7 @@ import {SubscribeProvider} from '@/components/context/SubscribeContext'
 import {CookiesProvider} from '@/components/context/CookiesContext'
 import {AnalyticsProvider} from '@/helpers/googleAnalytics' // TODO move to context?
 import {CurrencyProvider} from '@/components/hooks/useCurrency'
+import {SearchbarRefProvider} from '@/components/context/SearchbarRef'
 import Search from './screens/Blockchain/BlockchainHeader/Search'
 
 import './App.css'
@@ -167,7 +168,9 @@ const Providers = ({children}) => (
     <AnalyticsProvider>
       <CurrencyProvider>
         <SubscribeProvider>
-          <AutoSyncProvider>{children}</AutoSyncProvider>
+          <AutoSyncProvider>
+            <SearchbarRefProvider>{children}</SearchbarRefProvider>
+          </AutoSyncProvider>
         </SubscribeProvider>
       </CurrencyProvider>
     </AnalyticsProvider>

--- a/frontend/src/components/context/SearchbarRef.js
+++ b/frontend/src/components/context/SearchbarRef.js
@@ -1,0 +1,16 @@
+// @flow
+import React, {useRef, useContext} from 'react'
+
+type ContextType = any
+export const Context = React.createContext<ContextType>({})
+
+type Props = {|
+  children: React$Node,
+|}
+
+export const SearchbarRefProvider = ({children}: Props) => {
+  const ref = useRef(null)
+  return <Context.Provider value={ref}>{children}</Context.Provider>
+}
+
+export const useSearchbarRefContext = () => useContext(Context)

--- a/frontend/src/components/hooks/useToggle.js
+++ b/frontend/src/components/hooks/useToggle.js
@@ -1,0 +1,10 @@
+// @flow
+import {useState, useCallback} from 'react'
+
+const useToggle = (defaultValue: boolean = false) => {
+  const [state, setState] = useState(defaultValue)
+  const toggle = useCallback(() => setState((state) => !state), [setState])
+  return [state, toggle]
+}
+
+export default useToggle

--- a/frontend/src/components/visual/Searchbar.js
+++ b/frontend/src/components/visual/Searchbar.js
@@ -54,9 +54,9 @@ type ExternalProps = {
   placeholder: string,
   value: string,
   onSearch: (str: string) => any,
-  textFieldProps?: Object,
   onChange: (event: any) => any,
   loading?: boolean,
+  inputProps?: Object,
 }
 
 type Props = {
@@ -86,8 +86,8 @@ class Searchbar extends React.Component<Props> {
       handleOnChangeEvent,
       onSubmit,
       classes,
-      textFieldProps,
       loading,
+      inputProps,
     } = this.props
 
     return (
@@ -100,6 +100,8 @@ class Searchbar extends React.Component<Props> {
           placeholder={placeholder}
           onChange={handleOnChangeEvent}
           inputRef={this.inputRef}
+          inputProps={inputProps}
+          // eslint-disable-next-line react/jsx-no-duplicate-props
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -116,7 +118,6 @@ class Searchbar extends React.Component<Props> {
               focused: classes.focusedInput,
             },
           }}
-          {...textFieldProps}
         />
         <Button primary type="submit" variant="contained" className={classes.searchButton}>
           <Search fontSize="large" />

--- a/frontend/src/screens/Blockchain/BlockchainHeader/Search.js
+++ b/frontend/src/screens/Blockchain/BlockchainHeader/Search.js
@@ -9,10 +9,12 @@ import useReactRouter from 'use-react-router'
 import {useQuery} from 'react-apollo-hooks'
 import {defineMessages} from 'react-intl'
 import {makeStyles} from '@material-ui/styles'
-import {Typography} from '@material-ui/core'
+import {Typography, Portal} from '@material-ui/core'
 
 import {useI18n} from '@/i18n/helpers'
 import {Searchbar, LoadingError, Alert} from '@/components/visual'
+import {useSearchbarRefContext} from '@/components/context/SearchbarRef'
+
 import {routeTo} from '@/helpers/routes'
 import {useAnalytics} from '@/helpers/googleAnalytics'
 import {APOLLO_CACHE_OPTIONS} from '@/constants'
@@ -146,6 +148,13 @@ type SearchProps = {|
   isMobile?: boolean,
 |}
 
+const useTextfieldFocus = (defaultValue: boolean) => {
+  const [isFocused, setIsFocused] = useState(defaultValue)
+  const onFocus = useCallback(() => setIsFocused(true), [setIsFocused])
+  const onBlur = useCallback(() => setIsFocused(false), [setIsFocused])
+  return {isFocused, onFocus, onBlur}
+}
+
 const Search = ({isMobile = false}: SearchProps) => {
   const {translate: tr} = useI18n()
   const {history} = useReactRouter()
@@ -187,9 +196,14 @@ const Search = ({isMobile = false}: SearchProps) => {
 
   const showAlert = searchQuery && !error && !loading && !searchResult
 
+  const searchbarRef = useSearchbarRefContext()
+
+  const {isFocused: isSearchbarFocused, onFocus, onBlur} = useTextfieldFocus(false)
+
   return (
     <div className={classes.wrapper}>
       <Searchbar
+        inputProps={{onFocus, onBlur}}
         placeholder={tr(text.searchPlaceholder)}
         value={searchText}
         onChange={onChange}
@@ -224,7 +238,15 @@ const Search = ({isMobile = false}: SearchProps) => {
           />
         )}
       </ReactCSSTransitionGroup>
-      {!isMobile && <SearchHelpText className={showAlert ? classes.helpTextHidden : ''} />}
+      {isMobile ? (
+        <Portal container={searchbarRef.current}>
+          <SearchHelpText
+            className={!isSearchbarFocused || showAlert ? classes.helpTextHidden : ''}
+          />
+        </Portal>
+      ) : (
+        <SearchHelpText className={showAlert ? classes.helpTextHidden : ''} />
+      )}
     </div>
   )
 }

--- a/frontend/src/screens/Blockchain/BlockchainHeader/index.js
+++ b/frontend/src/screens/Blockchain/BlockchainHeader/index.js
@@ -5,9 +5,10 @@ import {defineMessages} from 'react-intl'
 import {compose} from 'redux'
 
 import OverviewMetrics from './OverviewMetrics'
-import Search, {SearchHelpText} from './Search'
+import Search from './Search'
 import {withI18n} from '@/i18n/helpers'
 import {isCrawler} from '@/helpers/userAgent'
+import {useSearchbarRefContext} from '@/components/context/SearchbarRef'
 
 const messages = defineMessages({
   header: 'Ada Blockchain Explorer',
@@ -33,39 +34,43 @@ const styles = ({palette, spacing}) =>
     },
   })
 
-const BlockchainHeader = ({classes, i18n: {translate}}) => (
-  <div className={classes.wrapper}>
-    <Grid
-      container
-      direction="column"
-      justify="space-around"
-      alignItems="center"
-      className={classes.wrapper}
-    >
-      {!isCrawler && (
-        <React.Fragment>
-          <Hidden mdUp>
-            <Grid item>
-              <SearchHelpText />
-            </Grid>
-          </Hidden>
-          <Grid item className={classes.metricsWrapper}>
-            <OverviewMetrics />
-          </Grid>
-        </React.Fragment>
-      )}
+const BlockchainHeader = ({classes, i18n: {translate}}) => {
+  const searchbarRef = useSearchbarRefContext()
+  return (
+    <div className={classes.wrapper}>
+      <Grid
+        container
+        direction="column"
+        justify="space-around"
+        alignItems="center"
+        className={classes.wrapper}
+      >
+        {!isCrawler && (
+          <React.Fragment>
+            <Hidden mdUp>
+              <Grid item>
+                <div ref={searchbarRef} />
+              </Grid>
+            </Hidden>
 
-      <Grid item xs={10} md={8} lg={6} className="w-100">
-        <Grid container direction="column" alignItems="stretch" className={classes.searchWrapper}>
-          <Typography variant="h1" align="center">
-            {translate(messages.header)}
-          </Typography>
-          <Hidden smDown>{!isCrawler && <Search />}</Hidden>
+            <Grid item className={classes.metricsWrapper}>
+              <OverviewMetrics />
+            </Grid>
+          </React.Fragment>
+        )}
+
+        <Grid item xs={10} md={8} lg={6} className="w-100">
+          <Grid container direction="column" alignItems="stretch" className={classes.searchWrapper}>
+            <Typography variant="h1" align="center">
+              {translate(messages.header)}
+            </Typography>
+            <Hidden smDown>{!isCrawler && <Search />}</Hidden>
+          </Grid>
         </Grid>
       </Grid>
-    </Grid>
-  </div>
-)
+    </div>
+  )
+}
 
 export default compose(
   withI18n,


### PR DESCRIPTION
This PR relates only to mobile resolutions.
On Mobile resolutions, the Searchbar is at the top and the description of how to write a query into Search is hidden.
This PR makes it possible to show this description when the Searchbar is focused - i.e. user has the cursor in it and hide it when Searchbar is not focused.