### PR TITLE
Close address modal

### DIFF
--- a/frontend/src/screens/Blockchain/Address/QRDialog.js
+++ b/frontend/src/screens/Blockchain/Address/QRDialog.js
@@ -47,6 +47,7 @@ const QRDialog = withMobileDialog()(
           <Grid
             container
             justify="center"
+            alignItems="center"
             direction="column"
             spacing={24}
             className={classes.dialogContent}


### PR DESCRIPTION
- Add close icon
- Fix content centering on mobile

Before:
![image](https://user-images.githubusercontent.com/837681/59183176-bf5fd100-8b6b-11e9-9b4d-c3314b7477a9.png)

After:
![image](https://user-images.githubusercontent.com/837681/59183411-2b423980-8b6c-11e9-8294-bff17d578824.png)
