### PR TITLE
Update page not found on staking to include left menu

### DIFF
--- a/frontend/src/screens/PageNotFound.js
+++ b/frontend/src/screens/PageNotFound.js
@@ -20,6 +20,9 @@ const useStyles = makeStyles((theme) => ({
   message: {
     marginBottom: theme.spacing.unit * 3,
   },
+  image: {
+    maxWidth: '100%',
+  },
 }))
 
 const PageNotFound = () => {
@@ -43,7 +46,7 @@ const PageNotFound = () => {
       <Typography className={classes.message} variant="h4">
         {tr(messages.notFound)}
       </Typography>
-      <img src={errorImage} alt="" />
+      <img src={errorImage} alt="" className={classes.image} />
     </Grid>
   )
 }

--- a/frontend/src/screens/Staking/index.js
+++ b/frontend/src/screens/Staking/index.js
@@ -124,6 +124,12 @@ const LayoutedPeople = () => (
   </CenteredLayout>
 )
 
+const StakingPageNotFound = () => (
+  <CenteredLayout>
+    <PageNotFound />
+  </CenteredLayout>
+)
+
 const PoolListQuerySynchronizer = synchronizedScreenFactory(
   LayoutedStakePoolList,
   useSetListScreenStorageFromQuery
@@ -205,7 +211,7 @@ export default () => {
           <Route exact path={routeTo.staking.charts()} component={ChartsQuerySynchronizer} />
           <Route exact path={routeTo.staking.location()} component={LocationQuerySynchronizer} />
           <Route exact path={routeTo.staking.people()} component={PeopleQuerySynchronizer} />
-          <Route component={PageNotFound} />
+          <Route component={StakingPageNotFound} />
         </Switch>
       </Grid>
     </StakingContextProvider>


### PR DESCRIPTION
Before: There was no left side-menu for `/staking/bad-url`
After: Side-menu is preserved.
![image](https://user-images.githubusercontent.com/837681/59188384-d0164400-8b77-11e9-8ae2-247e4386efd1.png)


