### PR TITLE
Do proper caching of useHistoricalPrice queries

### DIFF
--- a/frontend/src/components/visual/AdaValue.js
+++ b/frontend/src/components/visual/AdaValue.js
@@ -50,7 +50,7 @@ const useHistoricalPrice = (currency, timestamp, shouldFetch) => {
     {
       variables: {
         currency,
-        timestamp: moment(timestamp),
+        timestamp: moment(timestamp).utc().startOf('day').toISOString(),
       },
       skip: !shouldFetch,
     }


### PR DESCRIPTION
Previously the Historical ADA value was fetched for each new timestamp even though the value has a 1-day resolution.
Before: frequent "loading" dots in ADA value tooltip when user moved mouse pointer through blocks of an epoch
After: we should see "loading" dots only once per each new day
 