### PR TITLE
Put themes behind a feature flag

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -145,7 +145,7 @@ const TopBar = compose(withRouter)(({location: {pathname}}) => {
             <Grid container direction="row" alignItems="center">
               <Navbar currentPathname={pathname} items={getTranslatedNavItems(translate)} />
               <LanguageSelect />
-              {config.showStakingData && <ThemeSelect />}
+              {config.featureEnableThemes && <ThemeSelect />}
             </Grid>
           </Grid>
         </Grid>

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -15,9 +15,11 @@ export const OVERRIDABLE_ENV = [
   'REACT_APP_SENTRY_DSN',
   'REACT_APP_SENTRY_RELEASE_VERSION',
   'REACT_APP_GOOGLE_MAPS_API_KEY',
-  'REACT_APP_SHOW_STAKING_DATA',
 
-  // temporary
+  // TODO: rename to FEATURE_
+  'REACT_APP_SHOW_STAKING_DATA',
+  'REACT_APP_FEATURE_ENABLE_THEMES',
+
   'REACT_APP_FEATURE_ENABLE_RUSSIAN',
   'REACT_APP_FEATURE_ENABLE_SPANISH',
 ]
@@ -57,8 +59,11 @@ export default {
     releaseVersion: sentryRelease || '', // flow does not know about above assert
   },
 
+
+  // TODO: rename me once #633 is merged in
   showStakingData: env.REACT_APP_SHOW_STAKING_DATA === 'true',
 
+  featureEnableThemes: env.REACT_APP_FEATURE_ENABLE_THEMES === 'true',
   featureEnableRussian: env.REACT_APP_FEATURE_ENABLE_RUSSIAN === 'true',
   featureEnableSpanish: env.REACT_APP_FEATURE_ENABLE_SPANISH === 'true',
 }


### PR DESCRIPTION
Make themes support configurable.
Before: themes we always enabled when staking was enabled
After: themes are independent of staking