### PR TITLE
Fix mobile no-results styling

### DIFF
--- a/frontend/src/components/visual/Alert.js
+++ b/frontend/src/components/visual/Alert.js
@@ -34,7 +34,7 @@ const messages = defineMessages({
 
 const getBorderColorStyle = (backgroundColor) => darken(backgroundColor, 0.05)
 
-const useAppStyles = makeStyles(({type, spacing, palette}) =>
+const useAppStyles = makeStyles(({type, spacing, palette, breakpoints}) =>
   createStyles({
     wrapper: {
       padding: spacing.unit * 1.5,
@@ -56,8 +56,19 @@ const useAppStyles = makeStyles(({type, spacing, palette}) =>
     [TYPES.NO_RESULTS]: {
       backgroundColor: palette.noResults.background,
       border: `1px solid ${getBorderColorStyle(palette.noResults.background)}`,
+      // Note: not mobile-first approach because
+      // we have important overrides
+      [breakpoints.down('sm')]: {
+        width: 'unset !important',
+        position: 'fixed !important',
+        left: spacing.unit * 2,
+        right: spacing.unit * 2,
+      },
     },
     [TYPES.NEUTRAL]: {},
+    darkIconButton: {
+      color: palette.primary.main,
+    },
   })
 )
 
@@ -105,7 +116,12 @@ const Alert = ({title, type, message, className, onClose}: PropTypes) => {
             </Grid>
           </Grid>
         </Grid>
-        {onClose && <CloseIconButton onClick={onClose} />}
+        {onClose && (
+          <CloseIconButton
+            onClick={onClose}
+            className={type === TYPES.NO_RESULTS && classes.darkIconButton}
+          />
+        )}
       </Grid>
     </Paper>
   )

--- a/frontend/src/components/visual/CloseIconButton.js
+++ b/frontend/src/components/visual/CloseIconButton.js
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
 
 type ExternalProps = {
   onClick: Function,
-  className?: string,
+  className?: string | false | null,
 }
 
 const CloseIconButton = ({onClick, className, ...props}: ExternalProps) => {


### PR DESCRIPTION
2 changes
1) fix close icon color
2) make banner screen-wide to fix wrapping on small screens

Before:
![image](https://user-images.githubusercontent.com/837681/59333338-64a7b000-8cf8-11e9-84ec-c0ea72efc12e.png)
![image](https://user-images.githubusercontent.com/837681/59333377-7a1cda00-8cf8-11e9-9188-a938a9d12df7.png)

After:
![image](https://user-images.githubusercontent.com/837681/59333429-97ea3f00-8cf8-11e9-96a3-3ef095280d7e.png)
![image](https://user-images.githubusercontent.com/837681/59333470-ae909600-8cf8-11e9-9858-ed9c2c49440a.png)
