### PR TITLE
Futher fixing close icon color

### DIFF
--- a/frontend/src/components/visual/Alert.js
+++ b/frontend/src/components/visual/Alert.js
@@ -66,9 +66,6 @@ const useAppStyles = makeStyles(({type, spacing, palette, breakpoints}) =>
       },
     },
     [TYPES.NEUTRAL]: {},
-    darkIconButton: {
-      color: palette.primary.main,
-    },
   })
 )
 
@@ -119,7 +116,7 @@ const Alert = ({title, type, message, className, onClose}: PropTypes) => {
         {onClose && (
           <CloseIconButton
             onClick={onClose}
-            className={type === TYPES.NO_RESULTS && classes.darkIconButton}
+            color={type === TYPES.NO_RESULTS ? 'primary' : 'default'}
           />
         )}
       </Grid>

--- a/frontend/src/components/visual/CloseIconButton.js
+++ b/frontend/src/components/visual/CloseIconButton.js
@@ -7,24 +7,32 @@ import {IconButton} from '@material-ui/core'
 
 const useStyles = makeStyles((theme) => ({
   iconButton: {
-    'color': theme.palette.contentUnfocus,
     '&:hover': {
       color: theme.palette.primary.main,
     },
+  },
+  colorDefault: {
+    color: theme.palette.contentUnfocus,
+  },
+  colorPrimary: {
+    color: theme.palette.primary.main,
   },
 }))
 
 type ExternalProps = {
   onClick: Function,
   className?: string | false | null,
+  color?: 'default' | 'primary',
 }
 
-const CloseIconButton = ({onClick, className, ...props}: ExternalProps) => {
+const CloseIconButton = ({onClick, color = 'default', className, ...props}: ExternalProps) => {
   const classes = useStyles()
+  const colorClass = {default: classes.colorDefault, primary: classes.colorPrimary}[color]
+
   return (
     <IconButton
       color="primary"
-      className={cn(classes.iconButton, className)}
+      className={cn(classes.iconButton, colorClass, className)}
       onClick={onClick}
       {...props}
     >


### PR DESCRIPTION
- It seems like I had a different CSS ordering while I was developing #666
Before (supposedly fixed by #666 but it was probably some hotloading vs css issue):
![image](https://user-images.githubusercontent.com/837681/59425858-069dca00-8dd7-11e9-8193-04966f007365.png)

After:
![image](https://user-images.githubusercontent.com/837681/59425797-ef5edc80-8dd6-11e9-90f8-3fe6e69ca0fd.png)
