### PR TITLE
Staking navigation shadows

### DIFF
--- a/frontend/src/screens/Staking/SideMenu/NavigationBar.js
+++ b/frontend/src/screens/Staking/SideMenu/NavigationBar.js
@@ -7,6 +7,7 @@ import {Typography, Grid} from '@material-ui/core'
 import {Search, LocationOn, BarChart, History, Compare, People} from '@material-ui/icons'
 import {makeStyles} from '@material-ui/styles'
 import {defineMessages} from 'react-intl'
+import {fade} from '@material-ui/core/styles/colorManipulator'
 
 import NavLink from '@/components/common/NavLink'
 import {routeTo} from '@/helpers/routes'
@@ -26,24 +27,29 @@ const navigationMessages = defineMessages({
   people: 'People',
 })
 
-const useMenuItemStyles = makeStyles(({palette, spacing}) => ({
-  link: {
-    'background': palette.background.paper,
-    'padding': '35px 40px 35px 60px',
-    'textTransform': 'uppercase',
-    '&:hover': {
-      background: palette.background.paperContrast,
+const useMenuItemStyles = makeStyles(({palette, spacing}) => {
+  const shadow = `inset 0px 10px 20px -7px ${fade(palette.shadowBase, 0.12)}`
+  return {
+    link: {
+      'background': palette.background.paper,
+      'padding': '35px 40px 35px 60px',
+      'textTransform': 'uppercase',
+      '&:hover': {
+        background: palette.background.paperContrast,
+        boxShadow: shadow,
+      },
+      'borderBottom': `1px solid ${palette.unobtrusiveContentHighlight}`,
     },
-    'borderBottom': `1px solid ${palette.unobtrusiveContentHighlight}`,
-  },
-  active: {
-    background: palette.background.paperContrast,
-    color: palette.primary.main,
-  },
-  icon: {
-    paddingRight: spacing(2),
-  },
-}))
+    active: {
+      background: palette.background.paperContrast,
+      color: palette.primary.main,
+      boxShadow: shadow,
+    },
+    icon: {
+      paddingRight: spacing(2),
+    },
+  }
+})
 
 const MenuItem = ({active, label, icon}) => {
   const classes = useMenuItemStyles()


### PR DESCRIPTION
Add inner shadow to staking navigation menu items.

New
![new](https://user-images.githubusercontent.com/10008234/59773970-de1e4000-92ae-11e9-90b9-bf4c32e4b46b.png)

Old
![old](https://user-images.githubusercontent.com/10008234/59773981-e2e2f400-92ae-11e9-8039-f65e9d002cd2.png)
