### PR TITLE
Fix missing color override on ylabel of BarChart

### DIFF
--- a/frontend/src/screens/Home/Charts/BarChart.js
+++ b/frontend/src/screens/Home/Charts/BarChart.js
@@ -206,7 +206,7 @@ export default ({
             offset={-5}
             value={yLabel}
             position="insideLeft"
-            style={{textAnchor: 'middle'}}
+            style={{textAnchor: 'middle', fill: textColor}}
           />
         )}
       </YAxis>


### PR DESCRIPTION
This was visible in dark theme

Before:
![image](https://user-images.githubusercontent.com/837681/59487041-b0369700-8e7b-11e9-9f1a-c590083b5e47.png)

After:
![image](https://user-images.githubusercontent.com/837681/59487048-bc225900-8e7b-11e9-973b-7389b783f517.png)
