### PR TITLE
Fix "jumping" table on hover

### DIFF
--- a/frontend/src/components/visual/Table.js
+++ b/frontend/src/components/visual/Table.js
@@ -44,6 +44,7 @@ const useTableStyles = makeStyles(({hover, palette}) => ({
   },
   hoverableRow: {
     'transition': hover.transitionOut(['box-shadow']),
+    'borderTop': '1px solid transparent', // Note: for rows not to change size on hover
     '&:hover': {
       marginTop: '-1px',
       borderTop: `1px solid ${palette.unobtrusiveContentHighlight}`,


### PR DESCRIPTION
On hovering row, in table, it added border which resulted in adding 1px to the row and UI felt little "jumpy". Fixing it with a transparent border. Adding no screenshot as this needs interaction to see/test.