### PR TITLE
Fix click away listeners

### DIFF
--- a/frontend/src/TopBar.js
+++ b/frontend/src/TopBar.js
@@ -57,6 +57,9 @@ const useMobileMenuStyles = makeStyles(({palette, spacing}) => ({
   dropdownIcon: {
     color: '#BFC5D2', // TODO: consider adding to theme
   },
+  popper: {
+    zIndex: 99999, // We just always want it to be on top
+  },
 }))
 
 const MobileMenu = ({items = [], currentPathname}: any) => {
@@ -79,18 +82,25 @@ const MobileMenu = ({items = [], currentPathname}: any) => {
     [setIsOpen, anchorEl, setAnchorEl, isOpen]
   )
 
+  /* Note: not using IconButton as its hover does not look good when it wraps both icons,
+     and also on mobile that hover will not be visible anyway. */
   return (
     <ClickAwayListener onClickAway={onClose}>
-      {/* Note: not using IconButton as its hover does not look good when it wraps both icons,
-          and also on mobile that hover will not be visible anyway. */}
-      {/* Note: we get warning without using Fragment */}
-      <React.Fragment>
+      {/* Note: <div> is required by ClickAwayListener as it needs a component
+          that can directly cary a ref */}
+      <div>
         <div className={classes.mobileWrapper} onClick={onClick}>
           <img src={seizaLogoMobile} alt="logo" />
           <ArrowDownIcon className={classes.dropdownIcon} />
         </div>
         {isOpen && (
-          <Popper open={isOpen} anchorEl={anchorEl} transition placement="bottom-end">
+          <Popper
+            open={isOpen}
+            anchorEl={anchorEl}
+            transition
+            placement="bottom-end"
+            className={classes.popper}
+          >
             {({TransitionProps}) => (
               <Grow {...TransitionProps}>
                 <Card classes={{root: classes.mobileMenuWrapper}}>
@@ -109,7 +119,7 @@ const MobileMenu = ({items = [], currentPathname}: any) => {
             )}
           </Popper>
         )}
-      </React.Fragment>
+      </div>
     </ClickAwayListener>
   )
 }

--- a/frontend/src/components/visual/ComparisonMatrix/index.js
+++ b/frontend/src/components/visual/ComparisonMatrix/index.js
@@ -528,6 +528,9 @@ const useFullWidthStyles = makeStyles((theme) => ({
     left: 0,
     top: 0,
   },
+  clickAwayListenerChild: {
+    maxWidth: '100%',
+  },
 }))
 
 const FullScreenModeOpener = ({onClick}) => {
@@ -582,8 +585,15 @@ const ComparisonMatrix = (props: ComparisonMatrixProps) => {
           <Modal onClose={closeModal} open={isOpen} className={classes.modal}>
             <div className={classes.fakeModal} ref={fullScreenScrollRef}>
               <div className={classes.fullScreenWrapper}>
-                <ClickAwayListener onClickAway={closeModal} style={{position: 'relative'}}>
-                  <FullWidthComparisonMatrix fullScreenScrollRef={fullScreenScrollRef} {...props} />
+                <ClickAwayListener onClickAway={closeModal}>
+                  {/* Note: <div> is required by ClickAwayListener as it needs a component
+                      that can directly cary a ref */}
+                  <div className={classes.clickAwayListenerChild}>
+                    <FullWidthComparisonMatrix
+                      fullScreenScrollRef={fullScreenScrollRef}
+                      {...props}
+                    />
+                  </div>
                 </ClickAwayListener>
               </div>
             </div>


### PR DESCRIPTION
Click-away listeners stopped working after updating Material-UI. You could not close the mobile menu by clicking elsewhere, or comparison matrix in full-screen mode.