### PR TITLE
Use current epoch in history screen

### DIFF
--- a/frontend/src/screens/Staking/History/dataLoaders.js
+++ b/frontend/src/screens/Staking/History/dataLoaders.js
@@ -1,0 +1,55 @@
+// @flow
+import gql from 'graphql-tag'
+import idx from 'idx'
+import {useQuery} from 'react-apollo-hooks'
+
+import {useSelectedPoolsContext} from '../context/selectedPools'
+
+import {getMockedHistory} from './mockedData'
+
+// TOOD: Dont we already have hook/dataProvider that we can reuse
+// current epoch from?
+// TODO: should not current epoch/block be stored in global context?
+export const useLoadCurrentEpoch = () => {
+  const {error, loading, data} = useQuery(
+    gql`
+      query {
+        currentStatus {
+          latestBlock {
+            epoch
+          }
+        }
+      }
+    `
+  )
+
+  return {
+    error,
+    loading,
+    currentEpoch: idx(data, (_) => _.currentStatus.latestBlock.epoch),
+  }
+}
+
+export const useLoadSelectedPoolsData = () => {
+  const {selectedPools: poolHashes} = useSelectedPoolsContext()
+  const {loading, error, data} = useQuery(
+    gql`
+      query($poolHashes: [String!]!) {
+        stakePools(poolHashes: $poolHashes) {
+          name
+          poolHash
+        }
+      }
+    `,
+    {
+      variables: {poolHashes},
+    }
+  )
+  return {loading, error, data: idx(data, (_) => _.stakePools)}
+}
+
+export const useLoadPoolsHistory = (poolHashes: Array<string>, toEpoch: number) => ({
+  error: false,
+  loading: false,
+  data: getMockedHistory(poolHashes, toEpoch),
+})

--- a/frontend/src/screens/Staking/History/mockedData.js
+++ b/frontend/src/screens/Staking/History/mockedData.js
@@ -13,7 +13,6 @@ const getChangedProperties = () => {
   return PROPERTIES_VALUES.slice(0, changedPropertiesCount)
 }
 
-// TODO: for now ignores "current" and "next" epoch
 // TODO: very simple mock, get real data
 export const getMockedHistory = (poolsHashes: Array<string>, toEpoch: number) =>
   _.range(0, toEpoch + 1)


### PR DESCRIPTION
* introduce "dataLoaders" file for History
* probably will change with real data endpoint, at least for "mock" purpose

New
![new](https://user-images.githubusercontent.com/10008234/60266762-075f5180-98e9-11e9-81bd-18ebac26760c.png)

Old (epoch was hardcoded)
![old](https://user-images.githubusercontent.com/10008234/60266787-17773100-98e9-11e9-85a3-a6d073aa0db9.png)
