### PR TITLE
Fix disabled footer links

### DIFF
--- a/frontend/src/screens/Footer/MainFooter.js
+++ b/frontend/src/screens/Footer/MainFooter.js
@@ -214,7 +214,7 @@ const MainFooter = ({navItems}: Props) => {
               <ul className={classes.nav}>
                 {navItems.map(({link, label, disabledText}) => (
                   <li key={label}>
-                    {disabledText ? (
+                    {!link ? (
                       <DisabledLink {...{label, disabledText}} />
                     ) : (
                       <Link className={classes.link} to={link}>


### PR DESCRIPTION
The links were shown as disabled even when in top navigation they were enabled.