### PR TITLE
Fix open saved settings

### DIFF
--- a/frontend/src/screens/Staking/index.js
+++ b/frontend/src/screens/Staking/index.js
@@ -78,6 +78,9 @@ const synchronizedScreenFactory = (Screen, useSetScreenStorageFromQuery) => () =
   const {setScreenStorageFromQuery, getScreenUrlQuery} = useSetScreenStorageFromQuery()
   const {autoSync, setAutosync} = useAutoSyncContext()
 
+  // Note: we currently use localStorage and sessionStorage which is not available on server
+  if (!process.browser) return <Screen />
+
   const storageQuery = getScreenUrlQuery()
 
   React.useEffect(() => {


### PR DESCRIPTION
After clicking "Open saved settings" opened page did not reflect user settings.
Note: for now user needs to wait till apps get re-rendered on the client, as "Open saved settings" does not render properly on server-side.