### PR TITLE
Hotfix staking key

### DIFF
--- a/frontend/src/screens/Blockchain/StakingKey/User/index.js
+++ b/frontend/src/screens/Blockchain/StakingKey/User/index.js
@@ -163,10 +163,7 @@ const UserStakingKey = () => {
                   color="textPrimary"
                   className={classes.resetTextTransform}
                 >
-                  <Link
-                    monospace
-                    to={routeTo.stakingKey.stakePool(stakingKey.delegation.stakePoolHash)}
-                  >
+                  <Link monospace to={routeTo.stakepool(stakingKey.delegation.stakePoolHash)}>
                     {stakingKey.delegation.stakePoolHash}
                   </Link>
                 </Typography>


### PR DESCRIPTION
New:
Staking key http://localhost:3000/blockchain/staking-key/c4ca4238a0b923820dcc509a6f75849bc81e728d9d4c2f636f067f89cc14862c should now be working 
Old:
Staking key wasn't working.

@rizip1 check this: 
![image](https://user-images.githubusercontent.com/16564320/61104744-b5d1cd80-a477-11e9-9d20-2aebecc70c54.png)
maybe we should get back our custom `_error.js` page...
