### PR TITLE
Fix EM-345 (sidebar creating weird under-footer spacing)

### DIFF
--- a/frontend/src/screens/Staking/SideMenu/index.js
+++ b/frontend/src/screens/Staking/SideMenu/index.js
@@ -10,6 +10,9 @@ const useStyles = makeStyles((theme) => ({
   wrapper: {
     height: '100%',
     overflow: 'visible', // Note: sticky navigation is not working without this
+    // Note(ppershing): this fixes EM-345
+    display: 'flex',
+    flexDirection: 'column',
   },
 }))
 


### PR DESCRIPTION
Repro: Go to staking center, close newsletter, add many staking pools

Before:
![image](https://user-images.githubusercontent.com/837681/62110936-c7a4d480-b2af-11e9-9198-6d3fb3d7af6a.png)

After:
![image](https://user-images.githubusercontent.com/837681/62111014-f0c56500-b2af-11e9-8e77-051092c6be28.png)
