### PR TITLE
Make Summary Card good looking on mobile

### DIFF
--- a/frontend/src/components/visual/SummaryCard.js
+++ b/frontend/src/components/visual/SummaryCard.js
@@ -20,8 +20,12 @@ const useRowStyles = makeStyles((theme) => ({
     '&:after': {
       content: '""',
       display: 'block',
-      marginLeft: getDefaultSpacing(theme),
-      marginRight: getDefaultSpacing(theme),
+      marginLeft: getDefaultSpacing(theme) / 2,
+      marginRight: getDefaultSpacing(theme) / 2,
+      [theme.breakpoints.up('sm')]: {
+        marginLeft: getDefaultSpacing(theme),
+        marginRight: getDefaultSpacing(theme),
+      },
       border: `0.5px solid ${theme.palette.unobtrusiveContentHighlight}`,
     },
     '&:last-child:after': {
@@ -29,10 +33,16 @@ const useRowStyles = makeStyles((theme) => ({
     },
   },
   listRow: {
-    paddingTop: theme.spacing(2.5),
-    paddingBottom: theme.spacing(2.5),
-    paddingLeft: getDefaultSpacing(theme),
-    paddingRight: getDefaultSpacing(theme),
+    paddingTop: theme.spacing(1.25),
+    paddingBottom: theme.spacing(1.25),
+    paddingLeft: getDefaultSpacing(theme) / 2,
+    paddingRight: getDefaultSpacing(theme) / 2,
+    [theme.breakpoints.up('sm')]: {
+      paddingTop: theme.spacing(2.5),
+      paddingBottom: theme.spacing(2.5),
+      paddingLeft: getDefaultSpacing(theme),
+      paddingRight: getDefaultSpacing(theme),
+    },
   },
   clickableRow: {
     'transition': theme.hover.transitionOut(['box-shadow']),
@@ -76,7 +86,6 @@ const Row = ({children, onClick, className, hideSeparator = false, showLastSepar
         container
         direction="row"
         justify="space-between"
-        alignItems="center"
         onClick={onClick}
         className={cn(classes.listRow, className, clickable && classes.clickableRow)}
       >
@@ -86,7 +95,7 @@ const Row = ({children, onClick, className, hideSeparator = false, showLastSepar
   )
 }
 const Label = ({children}) => (
-  <Grid item xs={12} sm={4}>
+  <Grid item xs={4}>
     <Typography variant="body1" color="textSecondary">
       {children}
     </Typography>
@@ -98,16 +107,13 @@ const useValueStyles = makeStyles((theme) => ({
     /* Responsive layout tricks */
     width: '100%',
     textAlign: 'right',
-    [theme.breakpoints.down('xs')]: {
-      textAlign: 'left',
-    },
   },
 }))
 
 const Value = ({children}) => {
   const classes = useValueStyles()
   return (
-    <Grid container item xs={12} sm={8}>
+    <Grid container justify="flex-end" item xs={8}>
       <Typography variant="body1" component="span" className={classes.value}>
         {children}
       </Typography>


### PR DESCRIPTION
Note for programmers: the overflow of long words, (e.g. website name on stakepool) should be handled individually.  

Summary Card is changed on many places, few examples:

New:
![image](https://user-images.githubusercontent.com/16564320/62351375-90c7fc00-b505-11e9-9f3b-685d59d17d63.png)

Old:
![image](https://user-images.githubusercontent.com/16564320/62351399-a76e5300-b505-11e9-87d1-a912619f73aa.png)

New:
![image](https://user-images.githubusercontent.com/16564320/62351444-d2f13d80-b505-11e9-9b45-34b9e32503ea.png)

Old:
![image](https://user-images.githubusercontent.com/16564320/62351475-ebf9ee80-b505-11e9-90e0-07859cedef61.png)

New:
![image](https://user-images.githubusercontent.com/16564320/62351518-059b3600-b506-11e9-8be6-6be306d4d978.png)

Old: 
![image](https://user-images.githubusercontent.com/16564320/62351540-151a7f00-b506-11e9-9870-19ae5f337485.png)

New:
![image](https://user-images.githubusercontent.com/16564320/62351559-29f71280-b506-11e9-9c4a-ce36f7955aa7.png)

Old:
![image](https://user-images.githubusercontent.com/16564320/62351584-37ac9800-b506-11e9-868b-d633169fd461.png)

