### PR TITLE
Screen for simple staking simulator

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import {BrowserRouter, StaticRouter, Route, Switch, Redirect} from 'react-router
 import {CssBaseline, Grid} from '@material-ui/core'
 import {makeStyles} from '@material-ui/styles'
 import {defineMessages} from 'react-intl'
+import {matchPath} from 'react-router'
 
 import {routeTo, combinedBlockchainPath} from './helpers/routes'
 import Footer from './screens/Footer'
@@ -18,6 +19,7 @@ import Home from './screens/Home'
 import Blockchain from './screens/Blockchain'
 import BlockchainHeader from './screens/Blockchain/BlockchainHeader'
 import Staking from './screens/Staking'
+import StakingSimple from './screens/Staking/StakingSimple'
 import StakingPools from './screens/StakingPools'
 import More from './screens/More'
 import PageNotFound from './screens/PageNotFound'
@@ -47,6 +49,8 @@ const navigationMessages = defineMessages({
   termsOfUse: 'Terms of use',
   privacy: 'Privacy',
   disabledText: 'Coming soon',
+  simpleStaking: 'Simple staking simulator',
+  advancedStaking: 'Advanced staking simulator',
 })
 
 const useAppStyles = makeStyles((theme) => ({
@@ -78,6 +82,19 @@ const getTranslatedNavItems = (translate) =>
       link: routeTo.stakingCenter.home(),
       label: translate(navigationMessages.staking),
       disabledText: translate(navigationMessages.disabledText),
+      getIsActive: ({location, match}) => {
+        return !!match || matchPath(location.pathname, routeTo.stakingCenterSimple())
+      },
+      sublinks: [
+        {
+          link: routeTo.stakingCenterSimple(),
+          label: translate(navigationMessages.simpleStaking),
+        },
+        {
+          link: routeTo.stakingCenter.home(),
+          label: translate(navigationMessages.advancedStaking),
+        },
+      ],
     },
     {
       link: routeTo.stakingPoolsList(),
@@ -145,6 +162,7 @@ const AppLayout = () => {
                 </Route>
               )}
               {renderRouteDef({path: routeTo.stakingCenter.home(), component: Staking})}
+              {renderRouteDef({path: routeTo.stakingCenterSimple(), component: StakingSimple})}
               {renderRouteDef({path: routeTo.stakingPoolsList(), component: StakingPools})}
               {renderRouteDef({exact: true, path: routeTo.more(), component: More})}
               {renderRouteDef({exact: true, path: routeTo.termsOfUse(), component: Terms})}

--- a/frontend/src/components/common/NavLink.js
+++ b/frontend/src/components/common/NavLink.js
@@ -5,13 +5,14 @@ import {Route, Link} from 'react-router-dom'
 // TODO: make this reuseable and also use for main navigation
 // eslint-disable-next-line
 // Taken from: https://stackoverflow.com/questions/49962495/integrate-react-router-active-navlink-with-child-component
-export default ({to, children, className, activeClassName, ...rest}) => {
+export default ({to, children, className, activeClassName, getIsActive, ...rest}) => {
   const path = typeof to === 'object' ? to.pathname : to
   return (
     <Route
       path={path}
       children={({location, match}) => {
-        const isActive = !!match
+        const isActive = getIsActive ? getIsActive({location, match}) : !!match
+
         return (
           <Link {...rest} className={cn(className, isActive && activeClassName)} to={to}>
             {typeof children === 'function' ? children(isActive) : children}

--- a/frontend/src/components/common/Navbar.js
+++ b/frontend/src/components/common/Navbar.js
@@ -2,12 +2,12 @@
 import React from 'react'
 import cn from 'classnames'
 
-import {MenuList, MenuItem} from '@material-ui/core'
+import {MenuList, MenuItem, Typography} from '@material-ui/core'
 import {makeStyles} from '@material-ui/styles'
 import {fade} from '@material-ui/core/styles/colorManipulator'
 
 import {NavTypography, NavLink as Link} from '@/components/common'
-import {Tooltip} from '@/components/visual'
+import {Tooltip, Card} from '@/components/visual'
 
 const useStyles = makeStyles(({palette, spacing}) => ({
   list: {
@@ -67,21 +67,135 @@ const DisabledLink = ({label, disabledText, className}) => {
   )
 }
 
-const NavMenuItem = ({disabledText, label, link, isMobile}) => {
+const useNavbarLinkStyles = makeStyles(({palette}) => ({
+  active: {
+    color: `${palette.primary.main}!important`, // Yes, this is needed
+  },
+  link: {
+    '&:hover': {
+      color: palette.primary.dark,
+    },
+  },
+}))
+
+const useSublinksStyles = makeStyles((theme) => ({
+  tooltipChildren: {
+    display: 'inline-block',
+  },
+  linkText: {
+    color: theme.palette.text.secondary,
+    padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
+  },
+  link: {
+    textDecoration: 'none',
+  },
+  menuItem: {
+    padding: 0,
+    minHeight: 0,
+  },
+}))
+
+const useTooltipClasses = makeStyles((theme) => ({
+  tooltip: {
+    borderRadius: '10px',
+    padding: 0,
+  },
+}))
+
+const Sublink = ({children, to}) => {
+  const sublinkClasses = useSublinksStyles()
+  const navBarClasses = useNavbarLinkStyles()
+  return (
+    <Link to={to} className={sublinkClasses.link}>
+      {(isActive) => (
+        <Typography
+          variant="body1"
+          className={cn(
+            navBarClasses.link,
+            sublinkClasses.linkText,
+            isActive && navBarClasses.active
+          )}
+        >
+          {children}
+        </Typography>
+      )}
+    </Link>
+  )
+}
+
+const Sublinks = ({sublinks}) => {
+  const classes = useSublinksStyles()
+  return (
+    <Card>
+      <MenuList>
+        {sublinks.map(({link, label}) => (
+          <MenuItem key={link} className={classes.menuItem}>
+            <Sublink to={link}>{label}</Sublink>
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Card>
+  )
+}
+
+const WithSublinks = ({children, sublinks}) => {
+  const classes = useSublinksStyles()
+  const tooltipClasses = useTooltipClasses()
+  if (!sublinks) return children
+
+  const PopoverMenu = Tooltip
+
+  return (
+    <PopoverMenu
+      classes={tooltipClasses}
+      placement="bottom"
+      interactive
+      title={<Sublinks sublinks={sublinks} />}
+    >
+      <div className={classes.tooltipChildren}>{children}</div>
+    </PopoverMenu>
+  )
+}
+
+type SublinksType = Array<{link: string, label: string}>
+
+type NavMenuItemProps = {
+  disabledText?: ?string,
+  label: string,
+  link: ?string,
+  isMobile: boolean,
+  sublinks?: SublinksType,
+  getIsActive?: Function,
+}
+
+const NavMenuItem = ({
+  disabledText,
+  label,
+  link,
+  isMobile,
+  sublinks,
+  getIsActive,
+}: NavMenuItemProps) => {
   const classes = useStyles()
   return !link ? (
     <DisabledLink {...{label, disabledText}} className={cn(isMobile && classes.mobileLink)} />
   ) : (
-    <Link className={cn(classes.link, isMobile && classes.mobileLink)} to={link}>
-      {(isActive) => (
-        <NavbarLink
-          isActive={isActive}
-          className={!isMobile && isActive ? classes.underlineActive : ''}
-        >
-          {label}
-        </NavbarLink>
-      )}
-    </Link>
+    <WithSublinks sublinks={sublinks}>
+      <Link
+        getIsActive={getIsActive}
+        className={cn(classes.link, isMobile && classes.mobileLink)}
+        to={link}
+      >
+        {(isActive) => (
+          <NavbarLink
+            isActive={isActive}
+            className={!isMobile && isActive ? classes.underlineActive : ''}
+          >
+            {label}
+          </NavbarLink>
+        )}
+      </Link>
+    </WithSublinks>
   )
 }
 
@@ -89,6 +203,8 @@ export type NavItem = {
   link: string,
   label: string,
   disabledText?: ?string,
+  sublinks?: SublinksType,
+  getIsActive?: Function,
 }
 
 type NavMenuItemsProps = {
@@ -101,26 +217,15 @@ export const NavMenuItems = ({items = [], currentPathname}: NavMenuItemsProps) =
   return (
     <nav>
       <ul className={classes.list}>
-        {items.map(({link, label, disabledText}) => (
+        {items.map(({link, label, disabledText, sublinks, getIsActive}) => (
           <li key={label} className={classes.item}>
-            <NavMenuItem isMobile={false} {...{disabledText, link, label}} />
+            <NavMenuItem isMobile={false} {...{disabledText, link, label, sublinks, getIsActive}} />
           </li>
         ))}
       </ul>
     </nav>
   )
 }
-
-const useNavbarLinkStyles = makeStyles(({palette}) => ({
-  active: {
-    color: palette.primary.main,
-  },
-  link: {
-    '&:hover': {
-      color: palette.primary.dark,
-    },
-  },
-}))
 
 // TODO: is there a better name for this component?
 // Little ambiguity with NavLink
@@ -156,9 +261,9 @@ export const MobileNavMenuItems = ({
   const classes = useStyles()
   return (
     <MenuList>
-      {items.map(({link, label, disabledText}) => (
+      {items.map(({link, label, disabledText, getIsActive}) => (
         <MenuItem key={label} disabled={!link} onClick={onClose} className={classes.menuItem}>
-          <NavMenuItem {...{disabledText, link, label}} isMobile />
+          <NavMenuItem {...{disabledText, link, label, getIsActive}} isMobile />
         </MenuItem>
       ))}
     </MenuList>

--- a/frontend/src/components/visual/Tooltip.js
+++ b/frontend/src/components/visual/Tooltip.js
@@ -24,7 +24,7 @@ const Tooltip = ({classes: customClasses, enterTouchDelay = 0, ...props}) => {
   return (
     <MuiTooltip
       enterTouchDelay={enterTouchDelay}
-      classes={mergeStylesheets(classes, customClasses)}
+      classes={mergeStylesheets(customClasses, classes)}
       {...props}
     />
   )

--- a/frontend/src/helpers/routes.js
+++ b/frontend/src/helpers/routes.js
@@ -64,6 +64,7 @@ export const routeTo = {
     location: () => `${STAKING_CENTER_ROUTE}/location`,
     people: () => `${STAKING_CENTER_ROUTE}/people`,
   }),
+  stakingCenterSimple: () => enableIf(HAVE_STAKING_CENTER, '/staking-simple'),
   stakingPoolsList: () => enableIf(HAVE_STAKE_POOLS_LIST, STAKING_POOLS_LIST_ROUTE),
   // todo: refactor under legal key
   ...enableSectionIf(HAVE_LEGAL, {

--- a/frontend/src/screens/Staking/StakingSimple/Header.js
+++ b/frontend/src/screens/Staking/StakingSimple/Header.js
@@ -1,0 +1,52 @@
+// @flow
+
+import React from 'react'
+import {Grid, Typography} from '@material-ui/core'
+import {makeStyles} from '@material-ui/styles'
+import {defineMessages} from 'react-intl'
+
+import {useI18n} from '@/i18n/helpers'
+import {HeaderCard, HeaderCardContainer} from '@/components/common'
+
+import searchForStakepoolIcon from '@/static/assets/icons/staking-simulator/search-for-stakepool.svg'
+
+const messages = defineMessages({
+  header: 'Explore Stake Pools',
+  card1Title: 'Search',
+  card1Value: 'for most profitable stake pools for you.',
+})
+
+const useStyles = makeStyles(({palette, spacing}) => ({
+  wrapper: {
+    height: '250px',
+    background: palette.gradient,
+  },
+}))
+
+const Header = () => {
+  const classes = useStyles()
+  const {translate: tr} = useI18n()
+  return (
+    <Grid
+      container
+      className={classes.wrapper}
+      direction="column"
+      justify="space-evenly"
+      alignItems="center"
+    >
+      <Typography variant="h1">{tr(messages.header)}</Typography>
+      <Grid container direction="row" justify="center" alignItems="center">
+        <HeaderCardContainer>
+          <HeaderCard
+            smallPrimaryText
+            secondaryText={tr(messages.card1Value)}
+            primaryText={tr(messages.card1Title)}
+            icon={<img alt="" src={searchForStakepoolIcon} />}
+          />
+        </HeaderCardContainer>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default Header

--- a/frontend/src/screens/Staking/StakingSimple/index.js
+++ b/frontend/src/screens/Staking/StakingSimple/index.js
@@ -1,0 +1,41 @@
+// @flow
+
+import React from 'react'
+
+import {makeStyles} from '@material-ui/styles'
+
+import Header from './Header'
+import StakeList from '../StakeList'
+import {StakingContextProvider} from '../context'
+
+const useStyles = makeStyles((theme) => ({
+  centerWrapper: {
+    display: 'flex',
+    flex: 1,
+    justifyContent: 'center',
+    minWidth: 0, // needed for proper ellipsize in children components with flex
+  },
+  centeredItem: {
+    maxWidth: 1000,
+    width: '100%',
+    padding: `${theme.spacing(6)}px ${theme.spacing(2)}px`,
+  },
+}))
+
+// TODO: decide how links to that screen should look like (mobile)
+// TODO: use different stake pool cards with StakeList
+export default () => {
+  const classes = useStyles()
+  return (
+    <React.Fragment>
+      <Header />
+      <StakingContextProvider autoSync={false}>
+        <div className={classes.centerWrapper}>
+          <div className={classes.centeredItem}>
+            <StakeList />
+          </div>
+        </div>
+      </StakingContextProvider>
+    </React.Fragment>
+  )
+}


### PR DESCRIPTION
Desktop only (Mobile & Footer links in another PR)

![Screenshot from 2019-08-07 17-46-32](https://user-images.githubusercontent.com/10008234/62637235-59a97e80-b93b-11e9-856d-6bbee949e59b.png)

@ppershing @bigamasta can we "hack" highlighting of "staking-center" for both `/staking` and `/staking-simple` some better way? Of course that could be done by using `/staking/simple` and `/staking/advanced` as pathnames, however I think that Nico will not want one more extra url level.