### PR TITLE
Wrap Summary Card's row on mobile resolution

### DIFF
--- a/frontend/src/components/visual/SummaryCard.js
+++ b/frontend/src/components/visual/SummaryCard.js
@@ -95,7 +95,7 @@ const Row = ({children, onClick, className, hideSeparator = false, showLastSepar
   )
 }
 const Label = ({children}) => (
-  <Grid item xs={4}>
+  <Grid item xs={12} sm={4}>
     <Typography variant="body1" color="textSecondary">
       {children}
     </Typography>
@@ -106,14 +106,17 @@ const useValueStyles = makeStyles((theme) => ({
   value: {
     /* Responsive layout tricks */
     width: '100%',
-    textAlign: 'right',
+    textAlign: 'left',
+    [theme.breakpoints.up('sm')]: {
+      textAlign: 'right',
+    },
   },
 }))
 
 const Value = ({children}) => {
   const classes = useValueStyles()
   return (
-    <Grid container justify="flex-end" item xs={8}>
+    <Grid container justify="flex-end" item xs={12} sm={8}>
       <Typography variant="body1" component="span" className={classes.value}>
         {children}
       </Typography>

--- a/frontend/src/screens/Blockchain/Certificates/ActionList.js
+++ b/frontend/src/screens/Blockchain/Certificates/ActionList.js
@@ -558,10 +558,10 @@ const TransactionRow = ({tx}) => {
     <Row>
       <AdditionalRowLabel>{tr(messages.txHash)}</AdditionalRowLabel>
       <Value>
-        <Typography variant="body1" align="right">
+        <Typography variant="body1">
           <TxHashLink txHash={tx.txHash} />
         </Typography>
-        <Typography variant="caption" color="textSecondary" align="right">
+        <Typography variant="caption" color="textSecondary">
           {formatTimestamp(tx.timestamp)}
         </Typography>
       </Value>

--- a/frontend/src/screens/Blockchain/Stakepool/NonBootstrapPool/index.js
+++ b/frontend/src/screens/Blockchain/Stakepool/NonBootstrapPool/index.js
@@ -169,10 +169,10 @@ const Stakepool = () => {
             <Row>
               <Label>{tr(messages.totalRewards)}</Label>
               <Value>
-                <Typography variant="body1" align="right">
+                <Typography variant="body1">
                   <AdaValue value={stakepool.totalRewards.amount} showCurrency />
                 </Typography>
-                <Typography variant="caption" color="textSecondary" align="right">
+                <Typography variant="caption" color="textSecondary">
                   <FormattedMessage
                     // $FlowFixMe
                     id={messages.estimatedMissed.id}
@@ -204,7 +204,7 @@ const Stakepool = () => {
             <Row>
               <Label>{tr(messages.margin)}</Label>
               <Value>
-                <Typography variant="body1" align="right">
+                <Typography variant="body1">
                   {formatPercent(stakepool.currentMargin.margin)}{' '}
                   <FromTop1Message
                     value={formatPercent(stakepool.topPoolComparison.margin, {
@@ -212,7 +212,7 @@ const Stakepool = () => {
                     })}
                   />
                 </Typography>
-                <Typography variant="caption" color="textSecondary" align="right">
+                <Typography variant="caption" color="textSecondary">
                   {tr(messages.lastUpdate)} {formatTimestamp(stakepool.currentMargin.updatedAt)}
                 </Typography>
               </Value>
@@ -220,7 +220,7 @@ const Stakepool = () => {
             <Row>
               <Label>{tr(messages.cost)}</Label>
               <Value>
-                <Typography variant="body1" align="right">
+                <Typography variant="body1">
                   <AdaValue value={stakepool.currentCost.cost} showCurrency />
                   <FromTop1Message
                     value={
@@ -232,7 +232,7 @@ const Stakepool = () => {
                     }
                   />
                 </Typography>
-                <Typography variant="caption" color="textSecondary" align="right">
+                <Typography variant="caption" color="textSecondary">
                   {tr(messages.lastUpdate)} {formatTimestamp(stakepool.currentCost.updatedAt)}
                 </Typography>
               </Value>

--- a/frontend/src/screens/Blockchain/StakingKey/Tabs/DelegatedPoolInfoTab.js
+++ b/frontend/src/screens/Blockchain/StakingKey/Tabs/DelegatedPoolInfoTab.js
@@ -55,10 +55,10 @@ const DelegatedPoolInfoTab = ({stakePool, epochsInCurrentStakepool}) => {
       <Row>
         <Label>{translate(delegatedPoolMessages.currentTopStakePool)}</Label>
         <Value>
-          <Typography variant="body1" color="textSecondary" align="right">
+          <Typography variant="body1" color="textSecondary">
             {stakePool.topPoolComparison.topPool.name}
           </Typography>
-          <Typography variant="body1" align="right">
+          <Typography variant="body1">
             <Link monospace to={routeTo.stakepool(stakePool.topPoolComparison.topPool.hash)}>
               {stakePool.topPoolComparison.topPool.hash}
             </Link>


### PR DESCRIPTION
- Marta requested back wrapping of the rows on mobile because she realized that Nico wanted this, because it's more universal for different languages (some rows might be really long in some language and thus not looking that nice on mobile)
- this PR basically reverts relevants parts of #844

New:
![image](https://user-images.githubusercontent.com/16564320/63411401-c02ba380-c3f5-11e9-8529-e5327caf28c5.png)

Old:
![image](https://user-images.githubusercontent.com/16564320/63411426-d0438300-c3f5-11e9-960a-f9691cc469ad.png)
