### PR TITLE
Set less characters for hash ellipsized in middle

### DIFF
--- a/frontend/src/screens/Blockchain/Certificates/ActionList/utils.js
+++ b/frontend/src/screens/Blockchain/Certificates/ActionList/utils.js
@@ -51,8 +51,8 @@ export const StakingKeyLinkEllipsized = ({stakingKey}) => {
   )
 }
 
-const DESKTOP_CHARS_COUNT_SHOWN = 16
-const MOBILE_CHARS_COUNT_SHOWN = 8
+const DESKTOP_CHARS_COUNT_SHOWN = 8
+const MOBILE_CHARS_COUNT_SHOWN = 6
 export const EllipsizeMiddleFixed = ({value}) => {
   // Note(bigamasta): We're not using <MobileOnly> and <DesktopOnly>
   // because EllipsizeMiddleFixed is initially hidden in ExpansionPanel


### PR DESCRIPTION
characters count set to:
- desktop: 8
- mobile: 6
New:
![image](https://user-images.githubusercontent.com/16564320/63856571-3bff9000-c9a2-11e9-932e-5676c87dba04.png)
![image](https://user-images.githubusercontent.com/16564320/63857195-90efd600-c9a3-11e9-92be-d8764b35f0ee.png)

Old:
![image](https://user-images.githubusercontent.com/16564320/63857400-ea580500-c9a3-11e9-8970-79524da6d448.png)
![image](https://user-images.githubusercontent.com/16564320/63857408-f217a980-c9a3-11e9-9ad8-37d7df2e8469.png)
