### PR TITLE
Next bundler analyzer fix

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@material-ui/core": "^4.0.1",
     "@material-ui/icons": "^4.0.1",
     "@material-ui/styles": "^4.0.1",
+    "@next/bundle-analyzer": "^9.0.3",
     "@nivo/line": "^0.58.0",
     "@react-google-maps/api": "^1.5.1",
     "@sentry/browser": "^5.4.0",
@@ -89,7 +90,6 @@
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
-    "@next/bundle-analyzer": "^9.0.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-plugin-react-intl-auto": "^1.7.0",
     "babel-preset-react-app": "^9.0.0",


### PR DESCRIPTION
Production mode isn’t running because it’s missing the @next/bundler-analyzer package, because it’s defined in devDependencies instead of dependencies.

Already tested in staging as a hotfix