### PR TITLE
[Seiza for Yoroi] Accept language to be set by long locale abbreviation

### DIFF
--- a/frontend/src/components/context/intl.js
+++ b/frontend/src/components/context/intl.js
@@ -20,8 +20,12 @@ export const DEFAULT_LOCALE = 'en'
 
 export const LOCALE_KEY = 'locale'
 
-export const getValidatedLocale = (locale: string) =>
-  LANGUAGES.some((conf) => conf.value === locale) ? locale : DEFAULT_LOCALE
+export const getValidatedLocale = (locale: string) => {
+  // we accept also long version of locale
+  // which is passed from yoroi
+  const localeShort = locale.includes('-') ? locale.split('-')[0] : locale
+  return LANGUAGES.some((conf) => conf.value === localeShort) ? localeShort : DEFAULT_LOCALE
+}
 
 export const IntlProvider = ({children}: Props) => {
   const [locale, setLocale] = useCookieState(LOCALE_KEY, DEFAULT_LOCALE)


### PR DESCRIPTION
- so that yoroi can send `ja-JP` instead of `ja`
- I think this is the quickest solution right now