### PR TITLE
Tooltip to bottom

### DIFF
--- a/frontend/src/screens/StakingPools/fieldsConfig.js
+++ b/frontend/src/screens/StakingPools/fieldsConfig.js
@@ -150,7 +150,7 @@ export const fieldsConfig: Array<Config> = [
     getValue: ({data}: GetValueParams) => (
       <Tooltip
         interactive
-        placement="top"
+        placement="bottom"
         title={<NameTooltip data={data} />}
         leaveTouchDelay={3000}
       >


### PR DESCRIPTION
Move tooltip in stake pools table (name column) to bottom instead of to top.