### PR TITLE
Fix ellipsize middle copy

### DIFF
--- a/frontend/src/components/common/EntityIdCard.js
+++ b/frontend/src/components/common/EntityIdCard.js
@@ -6,7 +6,7 @@ import {fade} from '@material-ui/core/styles/colorManipulator'
 import {makeStyles} from '@material-ui/styles'
 import cn from 'classnames'
 
-import {Card} from '@/components/visual'
+import {Card, EllipsizeMiddle} from '@/components/visual'
 import {CopyToClipboard} from '@/components/common'
 import {useIsMobile} from '@/components/hooks/useBreakpoints'
 
@@ -161,11 +161,10 @@ export const EntityCardContent = ({
                 key={rawValue}
               >
                 <Typography
-                  noWrap={ellipsizeValue}
                   variant="body1"
                   className={cn(classes.value, monospaceValue && classes.monospace)}
                 >
-                  {value}
+                  <EllipsizeMiddle value={value} />
                 </Typography>
               </ReactCSSTransitionGroup>
 

--- a/frontend/src/components/visual/EllipsizeMiddle.js
+++ b/frontend/src/components/visual/EllipsizeMiddle.js
@@ -8,9 +8,9 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     // Used to disallow text selection. This component should be used together
     // with `CopyToClipboard` component to allow copying of the content.
-    // The reason is that having content in two <span> leads to unwanted space character when
+    // The reason is that having content in two <d> leads to unwanted space character when
     // copying directly.
-    userSelect: ({isFixed}) => (isFixed ? 'auto' : 'none'),
+    userSelect: ({isFixed}) => (isFixed ? 'auto' : 'all'),
     display: ({isFixed}) => (isFixed ? 'inline' : 'flex'),
   },
   ellipsizedSpan: {
@@ -38,7 +38,13 @@ const EllipsizeMiddle = ({value, startCharsCnt = null, endCharsCnt = 15}) => {
   }
 
   return typeof value === 'string' && value.length > endCharsCnt ? (
-    <span className={classes.wrapper}>
+    <span
+      className={classes.wrapper}
+      onCopy={(e) => {
+        e.clipboardData.setData('text/plain', value)
+        e.preventDefault()
+      }}
+    >
       {isFixed ? (
         <React.Fragment>
           {`${value.substring(0, startCharsCnt)}...${value.substring(value.length - endCharsCnt)}`}


### PR DESCRIPTION
- this can be possible fix for copying to clipboard with ellipsis in the middle, but I don't know about browser support yet
- please test on the deployment branch if it works for you (see entity ids)

![image](https://user-images.githubusercontent.com/16564320/64959563-b761ac80-d891-11e9-921f-4b3dbcd6282f.png)
