### PR TITLE
Redirect http to https except localhost

### DIFF
--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -18,5 +18,6 @@ SITEMAP_ROOT=
 DISABLE_CACHING=
 IS_YOROI=
 SEIZA_URL=
+FORCE_HTTPS=true
 YOROI_EXTENSION_HASH="bflmcienanhdibafopagdcaaenkmoago"
 REACT_APP_INSTANCES=[{"url":"http://local-seiza.com:3000","label":"Mainnet"},{"url":"http://test.local-seiza.com:3000","label":"Testnet"}]

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -10,6 +10,7 @@ const cachedApp = require('./serverCache')
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'
+const forceHttps = process.env.FORCE_HTTPS === 'true'
 const SITEMAP_ROOT = process.env.SITEMAP_ROOT
 const DISABLE_CACHING = process.env.DISABLE_CACHING === 'true'
 
@@ -53,6 +54,15 @@ app.prepare().then(() => {
 
   // To get https:// from req.protocol when running on heroku
   server.enable('trust proxy')
+
+  // https://stackoverflow.com/questions/7450940/automatic-https-connection-redirect-with-node-js-express
+  server.use ((req, res, next) => {
+    if (req.secure || !forceHttps) {
+      next()
+    } else {
+      res.redirect(301, `https://${req.headers.host}${req.url}`)
+    }
+  })
 
   // https://github.com/zeit/next.js/issues/1791
   server.use(


### PR DESCRIPTION
https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls