### PR TITLE
[WIP] Migrate to Tangata backend with Elastic v7

### DIFF
--- a/graphql-server/src/api/elastic.js
+++ b/graphql-server/src/api/elastic.js
@@ -184,7 +184,7 @@ const getElastic = (logger: Function) => {
     const request = {
       // $FlowFixMe validated above using `validate`
       index: `${ELASTIC_INDEX}.${type}`,
-      type,
+      // type,
       body,
     }
 


### PR DESCRIPTION
New backend with Tangata uses Elastic v7, so there are some little changes necessary.