### PR TITLE
Disable cookie & redirect

### DIFF
--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -164,7 +164,7 @@ class MyApp extends App {
       const cookiesProps = getCookiesProps(ctx)
 
       // Note: this can set cookie and redirect
-      handleLocaleParam(ctx, cookiesProps)
+      // handleLocaleParam(ctx, cookiesProps)
 
       const urlInfo = {
         domain: ctx.req ? ctx.req.headers.host : window.location.host,


### PR DESCRIPTION
To handle setting the locale based on the query, we do the following

1) Check if `locale` is present in the query
2) If yes, set the cookie and refresh the page

This means that the rest of the code can just always look at the cookie and not have if/else everywhere on locale based on the URL vs cookie.

However, this causes problems with the latest Chrome & Firefox versions: https://twitter.com/ChromiumDev/status/1224474784102150144

It's a little tricky to get this properly as commented here: https://github.com/Emurgo/Seiza/blob/3b6af5b2f19a9c79b259d11177dcb4ef621ac88c/frontend/src/pages/_app.js#L140

To avoid spending too much time on this, I just disable this for now.