### PR TITLE
Use window.ReactNativeWebView.postMessage() in mobile

### DIFF
--- a/frontend/src/helpers/iframeToYoroiMessaging.js
+++ b/frontend/src/helpers/iframeToYoroiMessaging.js
@@ -26,6 +26,12 @@ export const YoroiCallback = (selectedPools: SelectedPools) => {
 
   return useCallback(() => {
     const encodedDataForYoroi = relevantDataForYoroi(selectedPools)
+    let postMessage = window.parent.postMessage
+    if (window.ReactNativeWebView) {
+      postMessage = function(data) {
+        window.ReactNativeWebView.postMessage(data)
+      }
+    }
     switch (source) {
       case Source.CHROME_EXTENSION:
         window.parent.postMessage(
@@ -40,7 +46,7 @@ export const YoroiCallback = (selectedPools: SelectedPools) => {
         )
         break
       case Source.MOBILE:
-        window.parent.postMessage(encodedDataForYoroi, 'yoroi://simple-staking/selection')
+        postMessage(encodedDataForYoroi, 'yoroi://simple-staking/selection')
         break
       default:
         window.parent.postMessage(encodedDataForYoroi, source)

--- a/frontend/src/helpers/iframeToYoroiMessaging.js
+++ b/frontend/src/helpers/iframeToYoroiMessaging.js
@@ -25,13 +25,8 @@ export const YoroiCallback = (selectedPools: SelectedPools) => {
   const {value: mozId} = useManageSimpleContextValue(false, 'mozId', '')
 
   return useCallback(() => {
+    let postMessage
     const encodedDataForYoroi = relevantDataForYoroi(selectedPools)
-    let postMessage = window.parent.postMessage
-    if (window.ReactNativeWebView) {
-      postMessage = function(data) {
-        window.ReactNativeWebView.postMessage(data)
-      }
-    }
     switch (source) {
       case Source.CHROME_EXTENSION:
         window.parent.postMessage(
@@ -46,6 +41,12 @@ export const YoroiCallback = (selectedPools: SelectedPools) => {
         )
         break
       case Source.MOBILE:
+        postMessage = window.parent.postMessage
+        if (window.ReactNativeWebView) {
+          postMessage = function(data) {
+            window.ReactNativeWebView.postMessage(data)
+          }
+        }
         postMessage(encodedDataForYoroi, 'yoroi://simple-staking/selection')
         break
       default:


### PR DESCRIPTION
## Context
In mobile, we use the `WebView`  component to render Seiza. This component existed in React Native core modules but now it's been deprecated and moved to `react-native-community`.  On the other hand, iOS now doesn't support `UIWebView`, which was by default used by react-native core WebView. Even though we used a flag to avoid using `UIWebView`  and instead use `WKWebView`, the App Store is not accepting our app. In short, we need to move to `react-native-community`'s version of `WebView`.

## Issue
`react-native-community`'s `WebView`  [completely changes the way](https://github.com/react-native-community/react-native-webview/releases/tag/v5.0.0) to communicate between webview and react-native from v5 on.
They suggest using a `injectedJavascript` to still support the old API but it doesn't seem to work anymore. 

## Fix
I'm using a fix proposed in this [SO answer](https://github.com/react-native-community/react-native-webview/issues/323#issuecomment-511824940)

Tested on Android and iOS simulator.